### PR TITLE
use ome-zarr

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -9,6 +9,7 @@ dependencies:
   - greenlet
   - grpcio
   - h5py
+  - psutil
   - tifffile
   - scikit-image<=0.16
   - scikit-learn
@@ -28,8 +29,6 @@ dependencies:
   - tiktorch==20.7.1  # ilastik-forge
   # display
   - ipywidgets
-  # s3
-  - zarr  # for scripts reading from S3
-  - dask  # for scripts reading from S3
   - pip:
     - itkwidgets
+    - ome-zarr

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -31,7 +31,7 @@ Resources
 We will use an ilastik project created with ilastik version 1.3.3 to analyze 3D images of mouse blastocysts from the Image Data Resource (IDR).
 
 - :download:`ilastik model <../notebooks/pipelines/pixel-class-133.ilp>`.
-- Images from IDR `idr0062 <https://idr.openmicroscopy.org/webclient/?show=project-801>`_.
+- Images from IDR `idr0062 <https://idr.openmicroscopy.org/search/?query=Name:idr0062>`_.
 
 For convenience, the IDR data have been imported into the training
 OMERO.server. This is **only** because we **cannot** save results back to IDR

--- a/docs/ilastik_fiji.rst
+++ b/docs/ilastik_fiji.rst
@@ -48,7 +48,7 @@ not necessarily alphabetically ordered.
 Resources
 ---------
 
--  Images from IDR `idr0062 <https://idr.openmicroscopy.org/webclient/?show=project-801>`_.
+-  Images from IDR `idr0062 <https://idr.openmicroscopy.org/search/?query=Name:idr0062>`_.
 
 Step-by-step
 ------------
@@ -64,7 +64,7 @@ Manual training of z-stack segmentation in ilastik
 
 #.  Select a local directory to export to and save the image locally as an ``.h5`` file.
 
-#.  Repeat this step with several images from the `Blastocysts Dataset <https://idr.openmicroscopy.org/webclient/?show=dataset-7754>`_ of idr0062.
+#.  Repeat this step with several images from the `Blastocysts Dataset <https://idr.openmicroscopy.org/search/?query=Name:idr0062>`_ of idr0062.
 
 #.  Start ilastik.
 

--- a/docs/ilastik_fiji_script.rst
+++ b/docs/ilastik_fiji_script.rst
@@ -44,7 +44,7 @@ not necessarily alphabetically ordered.
 Resources
 ---------
 
--  Images from IDR `idr0062 <https://idr.openmicroscopy.org/webclient/?show=project-801>`_.
+-  Images from IDR `idr0062 <https://idr.openmicroscopy.org/search/?query=Name:idr0062>`_.
 
 -  Groovy script :download:`analyse_dataset_ilastik.groovy <../scripts/analyse_dataset_ilastik.groovy>`
 


### PR DESCRIPTION
A similar problem to the one fixed in https://github.com/ome/ome-zarr-py/pull/41 has been raised when loading the zarr data
This implies that the ``zarr`` notebooks are no longer working.
This PR install ``ome-zarr``, ``psutil`` now needs to be added since it now appears to be missing when installing from PyPI.
Check that the ``idr0062_pixel_classification_zarr.ipynb`` is running

cc @jrswedlow @joshmoore @pwalczysko 