### PR TITLE
Switch to conda, simplifications of installation instructions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [macos-12, macos-14, ubuntu-latest, windows-latest]
+        os: [macos-14, macos-latest, ubuntu-latest, windows-latest]
         envs: [binder/environment.yml]
     runs-on: ${{ matrix.os }}
     steps:

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - omero-py==5.19.*
   - pip
   - ipywidgets==7.8.5
-  - ilastik-forge::ilastik==1.4.1b22
+  - ilastik-forge::ilastik-core==1.4.1b22
   - ipykernel==6.29.5
   - yapsy==1.12.2
   - ome-zarr==0.9.0

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,8 +1,8 @@
 name: omero-guide-ilastik
 channels:
-  - anaconda
   - conda-forge
   - ilastik-forge
+  - nodefaults
 dependencies:
   - python==3.9.*
   - omero-py==5.19.*

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -10,6 +10,5 @@ dependencies:
   - ipywidgets==7.8.5
   - ilastik-forge::ilastik==1.4.1b22
   - ipykernel==6.29.5
-  - pip:
-    - yapsy==1.12.2
-    - ome-zarr==0.9.0
+  - yapsy==1.12.2
+  - ome-zarr==0.9.0

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -7,31 +7,16 @@ We will use the ilastik API to analyze data stored in an OMERO server. We will u
 Setup
 -----
 
-We recommend to install the dependencies using `Mamba <https://mamba.readthedocs.io>`_.
-
-* If you do not have any pre-existing conda installation, `install Mamba <https://mamba.readthedocs.io/en/latest/installation.html#installation>`_ and use `mambaforge <https://github.com/conda-forge/miniforge#mambaforge>`_
-* In case you have a pre-existing conda installation, you can install Mamba by either:
-
-  * Using the recommended way to install Mamba from `mambaforge <https://github.com/conda-forge/miniforge#mambaforge>`_. This will not invalidate your conda installation, but possibly your pre-existing conda envs will be in a different location (e.g. ``/Users/USER_NAME/opt/anaconda3/envs/``) then the new mamba envs (e.g. ``/Users/USER_NAME/mambaforge/envs/``). You can verify this by running ``conda env list``. The addition of ``export CONDA_ENVS_PATH=/Users/user/opt/anaconda3/envs/`` into your ``.bashprofile`` or ``.zprofile`` file will fix this. 
-  * Use the `Existing conda install <https://mamba.readthedocs.io/en/latest/installation.html#existing-conda-install>`_ way, i.e. run ``conda install mamba -n base -c conda-forge`` whilst in the base environment. This way can take much longer time than the recommended way described above, and might not lead to a successful installation, especially if run on arm64 (Apple Silicon) OS X.
+We recommend to install the dependencies using `Conda <https://docs.conda.io>`_.
+In case you do not have a conda installation we recommend downloading and installing the latest version of `Miniforge <https://github.com/conda-forge/miniforge?tab=readme-ov-file#download>`_.
 
 Create the environment running the commands below as written:
-
-For Windows, OS X x86_64 (NOT arm64 Apple Silicon), Linux::
 
     $ git clone https://github.com/ome/omero-guide-ilastik
     
     $ cd omero-guide-ilastik
 
-    $ mamba env create -f binder/environment.yml
-
-For OS X arm64 Apple Silicon::
-
-    $ git clone https://github.com/ome/omero-guide-ilastik 
-    
-    $ cd omero-guide-ilastik
-    
-    $ CONDA_SUBDIR=osx-64 mamba env create -f binder/environment.yml
+    $ conda env create -f binder/environment.yml
 
 and activate the newly created environment::
 
@@ -46,14 +31,14 @@ See also `Conda command reference <https://docs.conda.io/projects/conda/en/lates
 
 The following steps are only required if you want to run the notebooks.
 
-* If you have Anaconda installed:
-
-  * Start Jupyter from the Anaconda-navigator
-  * To register the environment, run ``python -m ipykernel install --user --name omero-guide-ilastik``
-  * Select the notebook you wish to run and select the ``Kernel>Change kernel>Python [conda env:omero-guide-ilastik]`` or ``Kernel>Change kernel>omero-guide-ilastik``.
-
-* If Anaconda is not installed:
+* If you installed Miniforge:
 
   * Open jupyter notebook i.e. ``jupyter notebook`` and select the ``omero-guide-ilastik`` kernel or ``[conda env:omero-guide-ilastik]`` according to what is available.
 
   To stop the notebook server, in the terminal where te server is running, press ``Ctrl C``. The following question will be asked in the terminal ``Shutdown this notebook server (y/[n])?``. Enter the desired choice.
+
+* If you have an Anaconda installation:
+
+  * Start Jupyter from the Anaconda-navigator
+  * To register the environment, run ``python -m ipykernel install --user --name omero-guide-ilastik``
+  * Select the notebook you wish to run and select the ``Kernel>Change kernel>Python [conda env:omero-guide-ilastik]`` or ``Kernel>Change kernel>omero-guide-ilastik``.


### PR DESCRIPTION
Mambaforge is officially deprecated, and conda uses libmamba per default for solving environments. So there is in practice no real difference to using mamba.

Furthermore, the environment can be installed nicely without having to rely on pip and even with native builds for osx-arm64.

Because of failures of CI on win, also switched to "lighter" (e.g. doesn't require pytorch) `ilastik-core` package for deps. A different solution would be adding the pytorch/nvidia channels to source pytorch - there are builds for windows there (maybe the better solution?). The notebooks seem to only go for pixel classification, which should be fine using those dependencies.

I couldn't test the actual processing though, as I don't know the password for the `trainer-1` user. I'll leave this PR in draft until I (or someone else) can verify the notebooks work as intended!